### PR TITLE
feat: add strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ pip install capvalidator
 
 ### 2A. Using the API
 
-We can perform a total validation of the CAP XML file:
+We can perform a total validation of the CAP XML file using `validate_xml(cap, strict)`.
+
+- `cap`: The CAP alert XML byte string.
+- `strict`: Whether or not signature validation is enforced. Defaults to `True`.
+
 ```python
 from capvalidator import validate_xml
 
@@ -37,7 +41,7 @@ with open(<cap-file-directory>, "rb") as f:
     cap = f.read()
 
 # Perform the validation
-result = validate_xml(cap)
+result = validate_xml(cap, strict=True)
 
 # Check the result
 passed = result.passed
@@ -49,7 +53,7 @@ if not passed:
 # Logic for handling valid CAP file
 ```
 
-Or, alternatively, a more refined validation:
+Or, alternatively, we can perform a more refined validation using `check_schema(cap)` and/or `check_signature(cap)`:
 ```python
 from capvalidator import check_schema, check_signature
 
@@ -81,7 +85,7 @@ if not passed:
 
 ```
 
-There is also a date extractor which you may find useful:
+There is also a date extractor `get_dates(cap)` which you may find useful:
 ```python
 from capvalidator import get_dates
 
@@ -103,6 +107,12 @@ We can perform a total validation of the CAP XML file:
 
 ```bash
 capvalidator validate <cap-file-directory>
+```
+
+To disable strict validation, that is, enforcement of a valid XML signature, we can use the `--no-strict` argument:
+
+```bash
+capvalidator validate <cap_file-directory> --no-strict
 ```
 
 Or, alternatively, more refined validations:

--- a/README.md
+++ b/README.md
@@ -108,14 +108,19 @@ We can perform a total validation of the CAP XML file:
 ```bash
 capvalidator validate <cap-file-directory>
 ```
+By default this includes schema and signature validation.
 
-To disable strict validation, that is, enforcement of a valid XML signature, we can use the `--no-strict` argument:
+To manually enable/disable enforcement of a valid XML signature, we can use the `--strict` or `--no-strict` arguments respectively:
 
 ```bash
-capvalidator validate <cap_file-directory> --no-strict
+capvalidator validate --strict <cap_file-directory> 
 ```
 
-Or, alternatively, more refined validations:
+```bash
+capvalidator validate --no-strict <cap_file-directory> 
+```
+
+Or, alternatively, for more refined validations we can use the `--type` argument:
 ```bash
 capvalidator validate --type schema <cap-file-directory>
 ```

--- a/src/capvalidator/__init__.py
+++ b/src/capvalidator/__init__.py
@@ -97,7 +97,7 @@ def validate_xml(cap, strict=True) -> ValidationResult:
             return signature_result
 
         # Otherwise, pass but warn the user
-        if signature_result.msg == "CAP alert has not been signed.":
+        if signature_result.message == "CAP alert has not been signed.":
             warning = "CAP XML file is valid but has not been signed." + \
                         "Consider signing alerts in the future."
             return ValidationResult(True, warning)

--- a/src/capvalidator/__init__.py
+++ b/src/capvalidator/__init__.py
@@ -21,7 +21,7 @@
 
 from .validate import Validator
 
-__version__ = '0.1.0-dev2'
+__version__ = '0.1.0-dev3'
 
 
 class ValidationResult:

--- a/src/capvalidator/cli.py
+++ b/src/capvalidator/cli.py
@@ -15,14 +15,17 @@ def cli():
 @click.option('--type', 'validation_type',
               type=click.Choice(['total', 'schema', 'signature']),
               required=False, default='total')
+@click.option('--strict/--no-strict', 'strict',
+              required=False, default=True,
+              help='Disable validation of the XML signature')
 @click.argument('cap_xml', type=click.File(mode="rb", errors="ignore"))
-def validate(ctx, cap_xml, validation_type) -> None:
+def validate(ctx, cap_xml, validation_type, strict=True) -> None:
     """Validate a CAP alert"""
 
     cap = cap_xml.read()
 
     if validation_type == "total":
-        result = validate_xml(cap)
+        result = validate_xml(cap, strict=strict)
     elif validation_type == "schema":
         result = check_schema(cap)
     elif validation_type == "signature":


### PR DESCRIPTION
**Major Changes**:
The `validate_xml` method now has a `strict` argument which defaults to `True`. If this is set to `False`, the XML signature validation result will not influence the validation. That is, if the signature validation fails, the validation will pass _but_ the message in the validation response will inform the user if the XML file has been signed or if the signature is invalid.

**Minor Changes**:
- Updated the CLI to have arguments `--strict` and `--no-strict` which support this feature.
- Updated the readme to explain this new feature.